### PR TITLE
Win VS2015 support

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -81,3 +81,8 @@ android/armeabi-v7a:
 
 android/x86:
 	ADDON_LIBS = libs/dlib/lib/android/x86/libdlib.a
+
+vs:
+	ADDON_LIBS = libs/dlib/lib/win/Release/dlib.lib
+
+

--- a/libs/dlib/include/dlib/windows_magic.h
+++ b/libs/dlib/include/dlib/windows_magic.h
@@ -7,6 +7,10 @@
 
 #ifdef WIN32
 
+#ifndef CreateSemaphore
+#define CreateSemaphore CreateSemaphoreW
+#endif
+
 // This file contains all the magical #defines you have to setup  before you
 // include the windows header files.  
 

--- a/libs/dlib/include/dlib/windows_magic.h
+++ b/libs/dlib/include/dlib/windows_magic.h
@@ -8,7 +8,9 @@
 #ifdef WIN32
 
 #ifndef CreateSemaphore
+#ifdef UNICODE
 #define CreateSemaphore CreateSemaphoreW
+#endif
 #endif
 
 // This file contains all the magical #defines you have to setup  before you


### PR DESCRIPTION
dlib library is auto-included now in windows Project Generator through addon_config.mk
(note, may require the nightly-0.9.8 PG build, due to a windows bug in the 0.9.8 PG)

also, hacky fix for dlib CreateSemaphore missing definition (not sure why dlib is not recognizing Windows API's definition, which is in <WinBase.h>)