### PR TITLE
Add initialization of 'imageDirty'

### DIFF
--- a/src/ofxFaceTracker2.cpp
+++ b/src/ofxFaceTracker2.cpp
@@ -15,6 +15,7 @@ ofxFaceTracker2::ofxFaceTracker2()
 		,imageRotation(0)
 		,numFaces(0)
 		,landmarkDetectorImageSize(-1)
+		,imageDirty(false)
 
 #ifdef TARGET_ANDROID
 		,faceDetectorImageSize(160*120*1.3)


### PR DESCRIPTION
Add initialization of 'imageDirty' to avoid OpenCV assertion error in threaded function.

If 'imageDirty' is not initialized, its initial value will sometime be true. 
Thread function may run runFaceDetector() before ofxFaceTracker2::update() is called, causing OpenCV assertion error since the input cv:Mat is null.